### PR TITLE
fix version specifier

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python setup.py install --offline --no-git --single-version-externally-managed --record record.txt
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
     - python >3
     - astropy
     - matplotlib
-    - sunpy <=1.0.3
+    - sunpy >=1.0.3
 
 test:
   requires:


### PR DESCRIPTION
The version specifier was wrong in the first build of 1.2